### PR TITLE
feat: add filter sidebar

### DIFF
--- a/src/Components/FilterSidebar.jsx
+++ b/src/Components/FilterSidebar.jsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from "react";
+import { tiles } from "../data/Products.js";
+
+export default function FilterSidebar({
+    category,
+    subcategory,
+    min,
+    max,
+    onCategory,
+    onSubcategory,
+    onMin,
+    onMax,
+}) {
+    const [open, setOpen] = useState(false);
+
+    const categories = useMemo(() => {
+        const map = new Map();
+        tiles.forEach((t) => {
+            if (!t.category) return;
+            const sub = t.subcategory;
+            if (!map.has(t.category)) map.set(t.category, new Set());
+            if (sub) map.get(t.category).add(sub);
+        });
+        return [
+            { name: "All", subs: [] },
+            ...Array.from(map.entries()).map(([name, subs]) => ({
+                name,
+                subs: Array.from(subs),
+            })),
+        ];
+    }, []);
+
+    const current = categories.find((c) => c.name === category);
+    const subcats = current?.subs ?? [];
+
+    return (
+        <>
+            {!open && (
+                <button
+                    className="md:hidden mb-4 border border-zinc-300 px-4 py-2 rounded"
+                    onClick={() => setOpen(true)}
+                >
+                    Filtros
+                </button>
+            )}
+            <aside
+                className={`fixed left-0 top-0 z-10 h-full w-64 bg-white p-4 border-r border-zinc-200 transform transition-transform md:translate-x-0 ${
+                    open ? "translate-x-0" : "-translate-x-full md:translate-x-0"
+                }`}
+            >
+                <div className="md:hidden flex justify-end mb-4">
+                    <button
+                        className="border border-zinc-300 px-2 py-1 rounded"
+                        onClick={() => setOpen(false)}
+                    >
+                        Cerrar
+                    </button>
+                </div>
+                <div className="mb-4">
+                    <label className="block text-sm mb-1 text-zinc-600">Categoría</label>
+                    <select
+                        value={category}
+                        onChange={(e) => {
+                            onCategory(e.target.value);
+                            onSubcategory("");
+                        }}
+                        className="w-full rounded border border-zinc-300 px-2 py-1"
+                    >
+                        {categories.map((c) => (
+                            <option key={c.name} value={c.name}>
+                                {c.name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                {subcats.length > 0 && (
+                    <div className="mb-4">
+                        <label className="block text-sm mb-1 text-zinc-600">Subcategoría</label>
+                        <select
+                            value={subcategory}
+                            onChange={(e) => onSubcategory(e.target.value)}
+                            className="w-full rounded border border-zinc-300 px-2 py-1"
+                        >
+                            <option value="">Todas</option>
+                            {subcats.map((s) => (
+                                <option key={s} value={s}>
+                                    {s}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+                <div className="mb-4">
+                    <label className="block text-sm mb-1 text-zinc-600">Precio mín.</label>
+                    <input
+                        type="number"
+                        value={min}
+                        onChange={(e) => onMin(e.target.value)}
+                        className="w-full rounded border border-zinc-300 px-2 py-1"
+                    />
+                </div>
+                <div className="mb-4">
+                    <label className="block text-sm mb-1 text-zinc-600">Precio máx.</label>
+                    <input
+                        type="number"
+                        value={max}
+                        onChange={(e) => onMax(e.target.value)}
+                        className="w-full rounded border border-zinc-300 px-2 py-1"
+                    />
+                </div>
+            </aside>
+        </>
+    );
+}
+

--- a/src/Screens/Shop.jsx
+++ b/src/Screens/Shop.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { tiles } from "../data/Products.js";
 import GlassProductCard from "../Components/GlassProductCard.jsx";
+import FilterSidebar from "../Components/FilterSidebar.jsx";
 
 export default function Shop() {
     const [searchParams] = useSearchParams();
@@ -10,80 +11,54 @@ export default function Shop() {
     const initialMax = searchParams.get("max") ?? "";
 
     const [category, setCategory] = useState("All");
+    const [subcategory, setSubcategory] = useState("");
     const [min, setMin] = useState(initialMin);
     const [max, setMax] = useState(initialMax);
-
-    const categories = useMemo(() => {
-        const set = new Set(["All"]);
-        tiles.forEach((t) => t?.category && set.add(t.category));
-        return Array.from(set);
-    }, []);
 
     const filtered = useMemo(() => {
         const q = query.trim();
         return tiles.filter((t) => {
             const matchesCat = category === "All" ? true : t.category === category;
+            const matchesSub = subcategory ? t.subcategory === subcategory : true;
             const price = typeof t.price === "number" ? t.price : 0;
             const matchesMin = min === "" ? true : price >= Number(min);
             const matchesMax = max === "" ? true : price <= Number(max);
             const matchesQuery = q
                 ? t.title?.toLowerCase().includes(q) || t.description?.toLowerCase().includes(q)
                 : true;
-            return matchesCat && matchesMin && matchesMax && matchesQuery;
+            return matchesCat && matchesSub && matchesMin && matchesMax && matchesQuery;
         });
-    }, [category, min, max, query]);
+    }, [category, subcategory, min, max, query]);
 
     return (
-        <section className="mx-auto max-w-7xl px-4 py-8">
-            <h1 className="mb-6 text-2xl font-bold">Shop</h1>
+        <>
+            <FilterSidebar
+                category={category}
+                subcategory={subcategory}
+                min={min}
+                max={max}
+                onCategory={(val) => {
+                    setCategory(val);
+                    setSubcategory("");
+                }}
+                onSubcategory={setSubcategory}
+                onMin={setMin}
+                onMax={setMax}
+            />
+            <section className="mx-auto max-w-7xl px-4 py-8 md:ml-64">
+                <h1 className="mb-6 text-2xl font-bold">Shop</h1>
 
-            <div className="mb-8 flex flex-wrap gap-4 items-end">
-                <label className="flex flex-col text-sm">
-                    <span className="mb-1 text-zinc-600">Categoría</span>
-                    <select
-                        value={category}
-                        onChange={(e) => setCategory(e.target.value)}
-                        className="rounded border border-zinc-300 px-3 py-2 text-sm"
-                    >
-                        {categories.map((cat) => (
-                            <option key={cat} value={cat}>
-                                {cat}
-                            </option>
+                {filtered.length === 0 ? (
+                    <p className="text-sm text-zinc-500">No hay productos para esta combinación.</p>
+                ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                        {filtered.map((item) => (
+                            <GlassProductCard key={item.id} item={item} />
                         ))}
-                    </select>
-                </label>
-
-                <label className="flex flex-col text-sm">
-                    <span className="mb-1 text-zinc-600">Precio mín.</span>
-                    <input
-                        type="number"
-                        value={min}
-                        onChange={(e) => setMin(e.target.value)}
-                        className="w-24 rounded border border-zinc-300 px-3 py-2"
-                    />
-                </label>
-
-                <label className="flex flex-col text-sm">
-                    <span className="mb-1 text-zinc-600">Precio máx.</span>
-                    <input
-                        type="number"
-                        value={max}
-                        onChange={(e) => setMax(e.target.value)}
-                        className="w-24 rounded border border-zinc-300 px-3 py-2"
-                    />
-                </label>
-            </div>
-
-            {filtered.length === 0 ? (
-                <p className="text-sm text-zinc-500">No hay productos para esta combinación.</p>
-            ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                    {filtered.map((item) => (
-                        <GlassProductCard key={item.id} item={item} />
-                    ))}
-                </div>
-            )}
-        </section>
+                    </div>
+                )}
+            </section>
+        </>
     );
 }
 


### PR DESCRIPTION
## Summary
- extract category and price controls into new `FilterSidebar` component
- support optional subcategory filter and mobile toggle sidebar
- integrate sidebar callbacks with `Shop` to update filter state

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f2cffccc832b9f62bf89aa0f0da7