### PR TITLE
Add product subcategories and reusable category list

### DIFF
--- a/src/Components/FilterSidebar.jsx
+++ b/src/Components/FilterSidebar.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
-import { tiles } from "../data/Products.js";
 
 export default function FilterSidebar({
+    categories,
     category,
     subcategory,
     min,
@@ -13,24 +13,12 @@ export default function FilterSidebar({
 }) {
     const [open, setOpen] = useState(false);
 
-    const categories = useMemo(() => {
-        const map = new Map();
-        tiles.forEach((t) => {
-            if (!t.category) return;
-            const sub = t.subcategory;
-            if (!map.has(t.category)) map.set(t.category, new Set());
-            if (sub) map.get(t.category).add(sub);
-        });
-        return [
-            { name: "All", subs: [] },
-            ...Array.from(map.entries()).map(([name, subs]) => ({
-                name,
-                subs: Array.from(subs),
-            })),
-        ];
-    }, []);
+    const allCategories = useMemo(
+        () => [{ name: "All", subs: [] }, ...categories],
+        [categories]
+    );
 
-    const current = categories.find((c) => c.name === category);
+    const current = allCategories.find((c) => c.name === category);
     const subcats = current?.subs ?? [];
 
     return (
@@ -66,7 +54,7 @@ export default function FilterSidebar({
                         }}
                         className="w-full rounded border border-zinc-300 px-2 py-1"
                     >
-                        {categories.map((c) => (
+                        {allCategories.map((c) => (
                             <option key={c.name} value={c.name}>
                                 {c.name}
                             </option>

--- a/src/Screens/Shop.jsx
+++ b/src/Screens/Shop.jsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { tiles } from "../data/Products.js";
+import { tiles, categories } from "../data/Products.js";
 import GlassProductCard from "../Components/GlassProductCard.jsx";
 import FilterSidebar from "../Components/FilterSidebar.jsx";
 
@@ -27,6 +27,7 @@ export default function Shop() {
                 ? t.title?.toLowerCase().includes(q)
                       || t.description?.toLowerCase().includes(q)
                       || t.category?.toLowerCase().includes(q)
+                      || t.subcategory?.toLowerCase().includes(q)
                 : true;
             return matchesCat && matchesSub && matchesMin && matchesMax && matchesQuery;
         });
@@ -35,6 +36,7 @@ export default function Shop() {
     return (
         <>
             <FilterSidebar
+                categories={categories}
                 category={category}
                 subcategory={subcategory}
                 min={min}

--- a/src/data/Products.js
+++ b/src/data/Products.js
@@ -16,6 +16,7 @@ export const tiles = [
 
         // NUEVO
         category: "Computers",
+        subcategory: "Laptops",
         isNew: true,
         isBestseller: false,
         isFeatured: true,
@@ -34,7 +35,8 @@ export const tiles = [
         },
 
         // NUEVO
-        category: "Smart Watches",
+        category: "Wearables",
+        subcategory: "Smart Watches",
         isNew: true,
         isBestseller: true,
         isFeatured: false,
@@ -55,7 +57,8 @@ export const tiles = [
         },
 
         // NUEVO
-        category: "Headphones",
+        category: "Audio",
+        subcategory: "Headphones",
         isNew: false,
         isBestseller: true,
         isFeatured: true,
@@ -75,8 +78,19 @@ export const tiles = [
 
         // NUEVO
         category: "Phones",
+        subcategory: "Smartphones",
         isNew: true,
         isBestseller: false,
         isFeatured: false,
     },
 ];
+
+export const categories = Array.from(
+    tiles.reduce((map, { category, subcategory }) => {
+        if (!category) return map;
+        if (!map.has(category)) map.set(category, new Set());
+        if (subcategory) map.get(category).add(subcategory);
+        return map;
+    }, new Map())
+).map(([name, subs]) => ({ name, subs: Array.from(subs) }));
+


### PR DESCRIPTION
## Summary
- Add `subcategory` to each product and export reusable `categories` list
- Use shared categories list in `FilterSidebar` and pass from `Shop`
- Include `subcategory` in shop search filtering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8fbc07920832ba743fc0ba217c0b1