### PR TITLE
feat: improve layout offset

### DIFF
--- a/src/Components/FilterSidebar.jsx
+++ b/src/Components/FilterSidebar.jsx
@@ -32,7 +32,7 @@ export default function FilterSidebar({
                 </button>
             )}
             <aside
-                className={`fixed left-0 top-0 z-10 h-full w-64 bg-white p-4 border-r border-zinc-200 transform transition-transform md:translate-x-0 ${
+                className={`sticky left-0 top-16 z-10 h-[calc(100vh-4rem)] overflow-y-auto w-64 bg-white p-4 border-r border-zinc-200 transform transition-transform md:translate-x-0 ${
                     open ? "translate-x-0" : "-translate-x-full md:translate-x-0"
                 }`}
             >

--- a/src/Screens/Shop.jsx
+++ b/src/Screens/Shop.jsx
@@ -49,7 +49,7 @@ export default function Shop() {
                 onMin={setMin}
                 onMax={setMax}
             />
-            <section className="mx-auto max-w-7xl px-4 py-8 md:ml-64">
+            <section className="mx-auto max-w-7xl px-4 py-8 md:ml-64 mt-4">
                 <h1 className="mb-6 text-2xl font-bold">Shop</h1>
 
                 {filtered.length === 0 ? (

--- a/src/routes/Layout.jsx
+++ b/src/routes/Layout.jsx
@@ -6,7 +6,7 @@ export default function Layout() {
     return (
         <div className="min-h-screen flex flex-col bg-white">
             <Navbar />
-            <main className="flex-1">
+            <main className="flex-1 pt-16">
                 <Outlet />
             </main>
             <Footer />


### PR DESCRIPTION
## Summary
- add top padding to main layout so content clears navbar
- make filter sidebar sticky and scrollable within viewport
- add spacing before shop section for visual separation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9019ea8cc832b8b25b8a4fbfc478c