### PR TITLE
feat: centralize search query matching

### DIFF
--- a/src/Components/Navbar.jsx
+++ b/src/Components/Navbar.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useNavigate, NavLink, Link } from "react-router-dom";
 import CartDrawer from "./CartDrawer.jsx";
 import { tiles } from "../data/Products";
+import { matchesQuery } from "../utils/matchesQuery.js";
 
 import {
   Disclosure,
@@ -44,16 +45,10 @@ export default function Navbar() {
       return;
     }
 
-    const q = value.toLowerCase();
+    const q = value;
     const pool = Array.isArray(tiles) ? tiles : [];
 
-    const filtered = pool
-      .filter(
-        (item) =>
-          item?.title?.toLowerCase().includes(q) ||
-          item?.category?.toLowerCase().includes(q)
-      )
-      .slice(0, 5);
+    const filtered = pool.filter((item) => matchesQuery(item, q)).slice(0, 5);
 
     setSuggestions(filtered);
   };

--- a/src/Screens/Shop.jsx
+++ b/src/Screens/Shop.jsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { tiles, categories } from "../data/Products.js";
 import GlassProductCard from "../Components/GlassProductCard.jsx";
 import FilterSidebar from "../Components/FilterSidebar.jsx";
+import { matchesQuery } from "../utils/matchesQuery.js";
 import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/react";
 import { ChevronDownIcon, FunnelIcon } from "@heroicons/react/24/outline";
 
@@ -39,13 +40,8 @@ export default function Shop() {
             const price = typeof t.price === "number" ? t.price : 0;
             const matchesMin = min === "" ? true : price >= Number(min);
             const matchesMax = max === "" ? true : price <= Number(max);
-            const matchesQuery = q
-                ? t.title?.toLowerCase().includes(q) ||
-                t.description?.toLowerCase().includes(q) ||
-                t.category?.toLowerCase().includes(q) ||
-                t.subcategory?.toLowerCase().includes(q)
-                : true;
-            return matchesCat && matchesSub && matchesMin && matchesMax && matchesQuery;
+            const matchesQueryFlag = matchesQuery(t, q);
+            return matchesCat && matchesSub && matchesMin && matchesMax && matchesQueryFlag;
         });
     }, [category, subcategory, min, max, query]);
 

--- a/src/utils/matchesQuery.js
+++ b/src/utils/matchesQuery.js
@@ -1,0 +1,15 @@
+export function matchesQuery(item, q) {
+  const query = q?.toLowerCase().trim();
+  if (!query) return true;
+  const fields = [
+    item.title,
+    item.eyebrow,
+    item.description,
+    item.category,
+    item.subcategory,
+    item.id,
+  ];
+  return fields.some(
+    (field) => typeof field === "string" && field.toLowerCase().includes(query)
+  );
+}


### PR DESCRIPTION
## Summary
- search Navbar suggestions across title, eyebrow, description, category and subcategory
- reuse matching helper in Shop listings
- add shared `matchesQuery` utility

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ef0e7464832b91efb83527435b1d