### PR TITLE
feat: improve search suggestions in navbar

### DIFF
--- a/src/Components/Navbar.jsx
+++ b/src/Components/Navbar.jsx
@@ -58,6 +58,26 @@ export default function Navbar() {
     setSuggestions(filtered);
   };
 
+  const highlight = (text) => {
+    if (!query) return text;
+    const lowerText = text.toLowerCase();
+    const lowerQuery = query.toLowerCase();
+    const parts = [];
+    let start = 0;
+    let index = lowerText.indexOf(lowerQuery);
+    let key = 0;
+    while (index !== -1) {
+      parts.push(text.slice(start, index));
+      parts.push(
+        <mark key={key++}>{text.slice(index, index + query.length)}</mark>
+      );
+      start = index + query.length;
+      index = lowerText.indexOf(lowerQuery, start);
+    }
+    parts.push(text.slice(start));
+    return parts;
+  };
+
   const handleSelect = (id) => {
     navigate(`/producto/${id}`);
     setSuggestions([]);
@@ -119,29 +139,38 @@ export default function Navbar() {
                       focus:outline-none focus:ring-2 focus:ring-gray-900
                     "
                   />
-                  {suggestions.length > 0 && (
-                    <ul className="absolute z-10 mt-1 w-full overflow-hidden rounded-md bg-white shadow-lg">
-                      {suggestions.map((item) => (
-                        <li key={item.id}>
-                          <button
-                            type="button"
-                            onClick={() => handleSelect(item.id)}
-                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
-                          >
-                            <img
-                              src={item.media?.src}
-                              alt={item.title}
-                              className="h-8 w-8 rounded object-cover"
-                            />
-                            <span>{String(item.title || "").replace(/\n/g, " ")}</span>
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-              </form>
-            </div>
+                {suggestions.length > 0 && (
+                  <div className="absolute z-10 mt-1 w-full grid gap-2 rounded-md bg-white p-2 shadow-lg">
+                    {suggestions.map((item) => (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => handleSelect(item.id)}
+                        className="flex items-center gap-3 rounded border border-gray-200 bg-white p-2 text-left text-sm shadow-sm hover:bg-gray-50"
+                      >
+                        <img
+                          src={item.media?.src}
+                          alt={item.title}
+                          className="h-10 w-10 rounded object-cover"
+                        />
+                        <div className="flex flex-col">
+                          <span className="font-medium text-gray-900">
+                            {highlight(String(item.title || "").replace(/\n/g, " "))}
+                          </span>
+                          <span className="text-xs text-gray-500">
+                            {highlight(item.eyebrow || "")}
+                          </span>
+                          <span className="text-sm font-semibold text-gray-900">
+                            {"$"}{item.price}
+                          </span>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </form>
+          </div>
 
             {/* CENTRO: tabs (sm+) */}
             <nav className="hidden sm:flex min-w-0 items-center justify-center gap-6 md:gap-10 lg:gap-14">
@@ -255,27 +284,36 @@ export default function Navbar() {
                     placeholder="Search"
                     className="w-full rounded-xl border border-gray-200 bg-gray-100 pl-10 pr-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-gray-900"
                   />
-                  {suggestions.length > 0 && (
-                    <ul className="absolute z-10 mt-1 w/full overflow-hidden rounded-md bg-white shadow-lg">
-                      {suggestions.map((item) => (
-                        <li key={item.id}>
-                          <button
-                            type="button"
-                            onClick={() => handleSelect(item.id)}
-                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
-                          >
-                            <img
-                              src={item.media?.src}
-                              alt={item.title}
-                              className="h-8 w-8 rounded object-cover"
-                            />
-                            <span>{String(item.title || "").replace(/\n/g, " ")}</span>
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
+                {suggestions.length > 0 && (
+                  <div className="absolute z-10 mt-1 w-full grid gap-2 rounded-md bg-white p-2 shadow-lg">
+                    {suggestions.map((item) => (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => handleSelect(item.id)}
+                        className="flex items-center gap-3 rounded border border-gray-200 bg-white p-2 text-left text-sm shadow-sm hover:bg-gray-50"
+                      >
+                        <img
+                          src={item.media?.src}
+                          alt={item.title}
+                          className="h-10 w-10 rounded object-cover"
+                        />
+                        <div className="flex flex-col">
+                          <span className="font-medium text-gray-900">
+                            {highlight(String(item.title || "").replace(/\n/g, " "))}
+                          </span>
+                          <span className="text-xs text-gray-500">
+                            {highlight(item.eyebrow || "")}
+                          </span>
+                          <span className="text-sm font-semibold text-gray-900">
+                            {"$"}{item.price}
+                          </span>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
               </form>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- display search suggestions as card grid with thumbnail, brand and price
- highlight matching query text within suggestions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ef128ee0832b9337b6ae4553bcf4