### PR TITLE
Add brand search support

### DIFF
--- a/src/Components/Navbar.jsx
+++ b/src/Components/Navbar.jsx
@@ -89,7 +89,9 @@ export default function Navbar() {
         .filter(
           (item) =>
             item?.title?.toLowerCase().includes(q) ||
-            item?.category?.toLowerCase().includes(q)
+            item?.category?.toLowerCase().includes(q) ||
+            item?.brand?.toLowerCase().includes(q) ||
+            item?.subcategory?.toLowerCase().includes(q)
         )
         .slice(0, 5);
 

--- a/src/utils/matchesQuery.js
+++ b/src/utils/matchesQuery.js
@@ -7,6 +7,7 @@ export function matchesQuery(item, q) {
     item.description,
     item.category,
     item.subcategory,
+    item.brand,
     item.id,
   ];
   return fields.some(


### PR DESCRIPTION
## Summary
- extend Navbar suggestions to match brand and subcategory
- include product brand in matchesQuery fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `node -e "import { matchesQuery } from './src/utils/matchesQuery.js'; import { tiles } from './src/data/Products.js'; console.log('Brand Apple:', tiles.filter(t => matchesQuery(t, 'Apple')).map(t => t.id)); console.log('Brand Samsung:', tiles.filter(t => matchesQuery(t, 'Samsung')).map(t => t.id)); console.log('Category Computers:', tiles.filter(t => matchesQuery(t, 'Computers')).map(t => t.id)); console.log('Category Audio:', tiles.filter(t => matchesQuery(t, 'Audio')).map(t => t.id));"`


------
https://chatgpt.com/codex/tasks/task_e_68a9f83b0908832b8ade6229ce3bb76c