### PR TITLE
Simplify search suggestions display

### DIFF
--- a/src/Components/Navbar.jsx
+++ b/src/Components/Navbar.jsx
@@ -38,30 +38,19 @@ function SearchSuggestions({ isLoading, suggestions, onSelect }) {
   }
   if (suggestions.length === 0) return null;
   return (
-    <ul className="absolute z-10 mt-1 w-full overflow-hidden rounded-md bg-white shadow-lg">
-      {suggestions.map((item) => (
-        <li key={item.id}>
-          <button
-            type="button"
-            onClick={() => onSelect(item.title)}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
-          >
-            <img
-              src={item.media?.src}
-              alt={item.title}
-              className="h-8 w-8 rounded object-cover"
-            />
-            <div className="flex flex-col flex-1 min-w-0">
-              <span className="truncate">{String(item.title || "").replace(/\n/g, " ")}</span>
-              <span className="truncate text-sm text-gray-500">
-                {String(item.description || "").replace(/\n/g, " ")}
-              </span>
-              <span className="text-sm text-gray-700">${item.price}</span>
-            </div>
-          </button>
-        </li>
-      ))}
-    </ul>
+      <ul className="absolute z-10 mt-1 w-full overflow-hidden rounded-md bg-white shadow-lg">
+        {suggestions.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(item.title)}
+              className="block w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 truncate"
+            >
+              {String(item.title || "").replace(/\n/g, " ")}
+            </button>
+          </li>
+        ))}
+      </ul>
   );
 }
 


### PR DESCRIPTION
## Summary
- Remove image, description and price from search suggestions
- Limit suggestion buttons to product titles only

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa07984998832b95ee9a37fcd6e141