### PR TITLE
Expand search synonyms and unify relevance scoring

### DIFF
--- a/src/Screens/Shop.jsx
+++ b/src/Screens/Shop.jsx
@@ -4,7 +4,7 @@ import { tiles, categories } from "../data/Products.js";
 import GlassProductCard from "../Components/GlassProductCard.jsx";
 import FilterSidebar from "../Components/FilterSidebar.jsx";
 import ProductSkeleton from "../Components/ProductSkeleton.jsx";
-import { getMatchScore } from "../utils/getMatchScore.js";
+import { getQueryScore } from "../utils/getQueryScore.js";
 import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/react";
 import { ChevronDownIcon, FunnelIcon } from "@heroicons/react/24/outline";
 
@@ -56,7 +56,7 @@ export default function Shop() {
   const filtered = useMemo(() => {
     const q = query.trim();
     return products
-      .map((t) => ({ ...t, score: getMatchScore(t, q) }))
+      .map((t) => ({ ...t, score: getQueryScore(t, q) }))
       .filter((t) => {
         const matchesCat = category === "All" ? true : t.category === category;
         const matchesSub = subcategory ? t.subcategory === subcategory : true;

--- a/src/utils/getQueryScore.js
+++ b/src/utils/getQueryScore.js
@@ -1,7 +1,10 @@
 const SYNONYMS = {
-  mac: ["apple", "notebook"],
-  apple: ["mac", "notebook"],
+  mac: ["apple", "notebook", "laptop"],
+  apple: ["mac", "notebook", "laptop", "iphone"],
   notebook: ["laptop", "mac", "apple"],
+  laptop: ["notebook", "mac", "apple"],
+  iphone: ["apple", "smartphone"],
+  smartphone: ["iphone", "apple"],
 };
 
 export function getQueryScore(item, q) {


### PR DESCRIPTION
## Summary
- extend search synonyms for devices like mac, iphone, and related terms
- use `getQueryScore` in shop screen to sort results consistently

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- manual `getQueryScore` checks for queries: mac, apple

------
https://chatgpt.com/codex/tasks/task_e_68aa07997864832ba9b0c39fdd6fb48b