### PR TITLE
Add search clear action and default product load

### DIFF
--- a/src/Components/Navbar.jsx
+++ b/src/Components/Navbar.jsx
@@ -113,6 +113,14 @@ export default function Navbar() {
     navigate(`/shop?query=${encodeURIComponent(query)}`);
   };
 
+  const handleClear = () => {
+    if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    setIsLoading(false);
+    setQuery("");
+    setSuggestions([]);
+    navigate("/shop");
+  };
+
   return (
     <>
       <Disclosure
@@ -167,6 +175,16 @@ export default function Navbar() {
                       focus:outline-none focus:ring-2 focus:ring-gray-900
                     "
                   />
+                  {query && (
+                    <button
+                      type="button"
+                      onClick={handleClear}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700"
+                      aria-label="Clear search"
+                    >
+                      <XMarkIcon className="size-4" />
+                    </button>
+                  )}
                   <SearchSuggestions
                     isLoading={isLoading}
                     suggestions={suggestions}
@@ -283,6 +301,16 @@ export default function Navbar() {
                     placeholder="Search"
                     className="w-full rounded-xl border border-gray-200 bg-gray-100 pl-10 pr-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-gray-900"
                   />
+                  {query && (
+                    <button
+                      type="button"
+                      onClick={handleClear}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700"
+                      aria-label="Clear search"
+                    >
+                      <XMarkIcon className="size-4" />
+                    </button>
+                  )}
                   <SearchSuggestions
                     isLoading={isLoading}
                     suggestions={suggestions}

--- a/src/Screens/Shop.jsx
+++ b/src/Screens/Shop.jsx
@@ -55,6 +55,17 @@ export default function Shop() {
 
   const filtered = useMemo(() => {
     const q = query.trim();
+    if (!q) {
+      return products.filter((t) => {
+        const matchesCat = category === "All" ? true : t.category === category;
+        const matchesSub = subcategory ? t.subcategory === subcategory : true;
+        const price = typeof t.price === "number" ? t.price : 0;
+        const matchesMin = min === "" ? true : price >= Number(min);
+        const matchesMax = max === "" ? true : price <= Number(max);
+        return matchesCat && matchesSub && matchesMin && matchesMax;
+      });
+    }
+
     return products
       .map((t) => ({ ...t, score: getQueryScore(t, q) }))
       .filter((t) => {
@@ -63,8 +74,7 @@ export default function Shop() {
         const price = typeof t.price === "number" ? t.price : 0;
         const matchesMin = min === "" ? true : price >= Number(min);
         const matchesMax = max === "" ? true : price <= Number(max);
-        const matchesQueryFlag = q ? t.score > 0 : true;
-        return matchesCat && matchesSub && matchesMin && matchesMax && matchesQueryFlag;
+        return matchesCat && matchesSub && matchesMin && matchesMax && t.score > 0;
       });
   }, [products, category, subcategory, min, max, query]);
 


### PR DESCRIPTION
## Summary
- Clear search input and suggestions with new handleClear in Navbar
- Show all products when query is empty in Shop screen

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68aa0a616034832b93f5eafdfb32d680