### PR TITLE
Add Redux cart functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   "dependencies": {
     "@headlessui/react": "^2.2.7",
     "@heroicons/react": "^2.2.0",
+    "@reduxjs/toolkit": "^2.2.7",
     "@tailwindcss/vite": "^4.1.12",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.540.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-redux": "^9.1.2",
     "react-router-dom": "^7.8.2",
     "tailwindcss": "^4.1.12"
   },

--- a/src/Components/CartDrawer.jsx
+++ b/src/Components/CartDrawer.jsx
@@ -1,6 +1,14 @@
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { useSelector, useDispatch } from "react-redux";
+import { removeItem, clearCart } from "../store/cartSlice.js";
 
 export default function CartDrawer({ open, onClose }) {
+  const dispatch = useDispatch();
+  const items = useSelector((state) => state.cart.items);
+  const money = (n) =>
+    new Intl.NumberFormat("es-AR", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(n);
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
   return (
     <>
       <div
@@ -8,7 +16,8 @@ export default function CartDrawer({ open, onClose }) {
         onClick={onClose}
       />
       <aside
-        className={`fixed right-0 top-0 z-40 h-full w-64 bg-white p-4 border-l border-gray-200 transform transition-transform ${open ? "translate-x-0" : "translate-x-full"}`}
+        className={`fixed right-0 top-0 z-40 h-full w-64 bg-white p-4 border-l border-gray-200 transform transition-transform ${
+open ? "translate-x-0" : "translate-x-full"}`}
         aria-hidden={!open}
       >
         <div className="flex justify-between mb-4">
@@ -21,7 +30,40 @@ export default function CartDrawer({ open, onClose }) {
             <XMarkIcon className="size-5" />
           </button>
         </div>
-        <p>Carrito vacío</p>
+        {items.length === 0 ? (
+          <p>Carrito vacío</p>
+        ) : (
+          <>
+            <ul className="space-y-2">
+              {items.map((item) => (
+                <li key={item.id} className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{item.name}</p>
+                    <p className="text-sm text-gray-600">
+                      {item.quantity} x {money(item.price)}
+                    </p>
+                  </div>
+                  <button
+                    className="text-sm text-red-500 hover:text-red-700"
+                    onClick={() => dispatch(removeItem(item.id))}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-4 flex justify-between font-semibold">
+              <span>Total</span>
+              <span>{money(total)}</span>
+            </div>
+            <button
+              className="mt-4 w-full rounded bg-gray-200 py-2 text-sm text-gray-700 hover:bg-gray-300"
+              onClick={() => dispatch(clearCart())}
+            >
+              Vaciar carrito
+            </button>
+          </>
+        )}
       </aside>
     </>
   );

--- a/src/Screens/ProductDetail.jsx
+++ b/src/Screens/ProductDetail.jsx
@@ -1,9 +1,12 @@
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { tiles } from "../data/Products";
+import { useDispatch } from "react-redux";
+import { addItem } from "../store/cartSlice.js";
 
 export default function ProductDetail() {
     const { id } = useParams();
     const navigate = useNavigate();
+    const dispatch = useDispatch();
 
     const product = tiles.find((p) => p.id === id);
 
@@ -21,6 +24,10 @@ export default function ProductDetail() {
         new Intl.NumberFormat("es-AR", { style: "currency", currency: curr, maximumFractionDigits: 0 }).format(n);
 
     const hasDiscount = typeof oldPrice === "number" && oldPrice > price;
+
+    const handleAddToCart = () => {
+        dispatch(addItem({ id: product.id, name: title, price, quantity: 1 }));
+    };
 
     return (
         <section className="mx-auto max-w-6xl px-4 py-8">
@@ -49,7 +56,7 @@ export default function ProductDetail() {
                     {description && <p className="mt-4 text-zinc-700">{description}</p>}
 
                     <div className="mt-8 flex gap-3">
-                        <button className="rounded-xl bg-indigo-600 px-5 py-3 text-white font-medium hover:bg-indigo-700">
+                        <button onClick={handleAddToCart} className="rounded-xl bg-indigo-600 px-5 py-3 text-white font-medium hover:bg-indigo-700">
                             Agregar al carrito
                         </button>
                         <button className="rounded-xl border border-zinc-300 px-5 py-3 font-medium text-zinc-800 hover:border-zinc-400">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { store } from "./store/store.js";
 import App from "./App.jsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
     <React.StrictMode>
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
-    </React.StrictMode>
+        <Provider store={store}>
+            <BrowserRouter>
+                <App />
+            </BrowserRouter>
+        </Provider>
+    </React.StrictMode>,
 );

--- a/src/store/cartSlice.js
+++ b/src/store/cartSlice.js
@@ -1,0 +1,29 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const cartSlice = createSlice({
+  name: "cart",
+  initialState: {
+    items: [],
+  },
+  reducers: {
+    addItem(state, action) {
+      const item = action.payload;
+      const existing = state.items.find((i) => i.id === item.id);
+      if (existing) {
+        existing.quantity += item.quantity || 1;
+      } else {
+        state.items.push({ ...item, quantity: item.quantity || 1 });
+      }
+    },
+    removeItem(state, action) {
+      const id = action.payload;
+      state.items = state.items.filter((item) => item.id !== id);
+    },
+    clearCart(state) {
+      state.items = [];
+    },
+  },
+});
+
+export const { addItem, removeItem, clearCart } = cartSlice.actions;
+export default cartSlice.reducer;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,0 +1,8 @@
+import { configureStore } from "@reduxjs/toolkit";
+import cartReducer from "./cartSlice.js";
+
+export const store = configureStore({
+  reducer: {
+    cart: cartReducer,
+  },
+});


### PR DESCRIPTION
## Summary
- integrate Redux store and provider
- display and manage cart items in drawer
- allow adding products to cart from detail page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa10e15b44832bb285f8464d88e9be