### PR TITLE
Add cart dispatch to product views

### DIFF
--- a/src/Components/GlassProductCard.jsx
+++ b/src/Components/GlassProductCard.jsx
@@ -1,9 +1,12 @@
 // src/Components/GlassProductCard.jsx
 // Card clickeable en estilo claro, sin blur ni glass, textos más oscuros.
 import { Link } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { addItem } from "../store/cartSlice";
 import { productUrl } from "../routes/paths"; // ajustá el path si tu estructura difiere
 
 export default function GlassProductCard({ item }) {
+    const dispatch = useDispatch();
     const {
         id,
         brand,
@@ -36,18 +39,19 @@ export default function GlassProductCard({ item }) {
     const to = id ? productUrl(id) : (cta?.href || "#");
 
     return (
-        <Link
-            to={to}
-            className={[
-                "group relative block overflow-hidden rounded-2xl p-5 sm:p-6 h-full",
-                "bg-white border border-zinc-200 shadow-md",
-                "transition hover:-translate-y-[2px] hover:shadow-lg",
-                "focus:outline-none focus-visible:ring-2 focus-visible:ring-black/20",
-                "focus-visible:ring-offset-2 focus-visible:ring-offset-white",
-                "flex flex-col text-zinc-900",
-            ].join(" ")}
-            aria-label={title}
-        >
+        <div className="flex flex-col h-full">
+            <Link
+                to={to}
+                className={[
+                    "group relative block overflow-hidden rounded-2xl p-5 sm:p-6 flex-1",
+                    "bg-white border border-zinc-200 shadow-md",
+                    "transition hover:-translate-y-[2px] hover:shadow-lg",
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-black/20",
+                    "focus-visible:ring-offset-2 focus-visible:ring-offset-white",
+                    "flex flex-col text-zinc-900",
+                ].join(" ")}
+                aria-label={title}
+            >
             {/* Top bar: marca + precio (+ descuento si aplica) */}
             <div className="flex flex-wrap items-start justify-between gap-2 mb-3">
                 {brand && (
@@ -99,7 +103,17 @@ export default function GlassProductCard({ item }) {
                 </div>
             )}
 
-            <div className="mt-auto" />
-        </Link>
+                <div className="mt-auto" />
+            </Link>
+            <button
+                onClick={(e) => {
+                    e.preventDefault();
+                    dispatch(addItem({ ...item, quantity: 1 }));
+                }}
+                className="mt-4 rounded-xl bg-indigo-600 px-5 py-2 text-white font-medium hover:bg-indigo-700"
+            >
+                Agregar al carrito
+            </button>
+        </div>
     );
 }

--- a/src/Screens/ProductDetail.jsx
+++ b/src/Screens/ProductDetail.jsx
@@ -1,9 +1,12 @@
 import { useParams, useNavigate, Link } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { addItem } from "../store/cartSlice";
 import { tiles } from "../data/Products";
 
 export default function ProductDetail() {
     const { id } = useParams();
     const navigate = useNavigate();
+    const dispatch = useDispatch();
 
     const product = tiles.find((p) => p.id === id);
 
@@ -49,7 +52,10 @@ export default function ProductDetail() {
                     {description && <p className="mt-4 text-zinc-700">{description}</p>}
 
                     <div className="mt-8 flex gap-3">
-                        <button className="rounded-xl bg-indigo-600 px-5 py-3 text-white font-medium hover:bg-indigo-700">
+                        <button
+                            onClick={() => dispatch(addItem({ ...product, quantity: 1 }))}
+                            className="rounded-xl bg-indigo-600 px-5 py-3 text-white font-medium hover:bg-indigo-700"
+                        >
                             Agregar al carrito
                         </button>
                         <button className="rounded-xl border border-zinc-300 px-5 py-3 font-medium text-zinc-800 hover:border-zinc-400">

--- a/src/store/cartSlice.js
+++ b/src/store/cartSlice.js
@@ -1,0 +1,1 @@
+export const addItem = (item) => ({ type: "cart/addItem", payload: item });


### PR DESCRIPTION
## Summary
- enable adding products to cart from detail page
- allow adding products to cart directly from product card
- provide simple cart action stub

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa10e12c18832bb42fd2a90d5a4aca