### PR TITLE
feat: add Redux store

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   "dependencies": {
     "@headlessui/react": "^2.2.7",
     "@heroicons/react": "^2.2.0",
+    "@reduxjs/toolkit": "^2.2.3",
     "@tailwindcss/vite": "^4.1.12",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.540.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-redux": "^9.1.1",
     "react-router-dom": "^7.8.2",
     "tailwindcss": "^4.1.12"
   },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import store from "./store";
 import App from "./App.jsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
     <React.StrictMode>
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
-    </React.StrictMode>
+        <Provider store={store}>
+            <BrowserRouter>
+                <App />
+            </BrowserRouter>
+        </Provider>
+    </React.StrictMode>,
 );
+

--- a/src/store/cartSlice.js
+++ b/src/store/cartSlice.js
@@ -1,0 +1,32 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+    items: [],
+};
+
+const cartSlice = createSlice({
+    name: "cart",
+    initialState,
+    reducers: {
+        addItem: (state, action) => {
+            state.items.push(action.payload);
+        },
+        removeItem: (state, action) => {
+            state.items = state.items.filter((item) => item.id !== action.payload);
+        },
+        clearCart: (state) => {
+            state.items = [];
+        },
+        updateQuantity: (state, action) => {
+            const { id, quantity } = action.payload;
+            const item = state.items.find((item) => item.id === id);
+            if (item) {
+                item.quantity = quantity;
+            }
+        },
+    },
+});
+
+export const { addItem, removeItem, clearCart, updateQuantity } = cartSlice.actions;
+export default cartSlice.reducer;
+

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,11 @@
+import { configureStore } from "@reduxjs/toolkit";
+import cartReducer from "./cartSlice";
+
+export const store = configureStore({
+    reducer: {
+        cart: cartReducer,
+    },
+});
+
+export default store;
+


### PR DESCRIPTION
## Summary
- add Redux Toolkit and React Redux dependencies
- implement cart slice and configure store
- wrap App in Redux Provider

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@reduxjs%2ftoolkit)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa10e31278832ba7014f99e8762d1f