### PR TITLE
feat: add cart slice with persistence and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,52 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Cart state management
+
+Este proyecto incluye un slice de Redux (`cartSlice`) para manejar el carrito de compras.
+
+### Estado inicial
+
+```js
+{
+  items: [],
+  totalQuantity: 0,
+  totalAmount: 0
+}
+```
+
+El estado se persiste en `localStorage` para mantener los datos entre recargas.
+
+### Acciones principales
+
+- `addItem({ id, title, price, quantity })`
+- `removeItem(id)`
+- `updateQuantity({ id, quantity })`
+- `clearCart()`
+
+### Ejemplo de uso en componentes
+
+```jsx
+import { useDispatch, useSelector } from "react-redux";
+import { addItem, removeItem } from "../store/cartSlice";
+
+function Product({ product }) {
+  const dispatch = useDispatch();
+  return (
+    <button onClick={() => dispatch(addItem(product))}>Agregar</button>
+  );
+}
+
+function Cart() {
+  const items = useSelector((s) => s.cart.items);
+  return items.map((i) => (
+    <div key={i.id}>
+      {i.title}
+      <button onClick={() => dispatch(removeItem(i.id))}>Quitar</button>
+    </div>
+  ));
+}
+```
+
+Consulta `src/Components/GlassProductCard.jsx` y `src/Components/CartDrawer.jsx` para ejemplos completos de integración.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --host",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",
@@ -31,6 +32,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/Components/CartDrawer.jsx
+++ b/src/Components/CartDrawer.jsx
@@ -1,14 +1,34 @@
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  removeItem,
+  updateQuantity,
+  clearCart,
+} from "../store/cartSlice";
 
 export default function CartDrawer({ open, onClose }) {
+  const { items, totalAmount } = useSelector((s) => s.cart);
+  const dispatch = useDispatch();
+
+  const handleQtyChange = (id, qty) => {
+    const quantity = Number(qty);
+    if (quantity > 0) {
+      dispatch(updateQuantity({ id, quantity }));
+    }
+  };
+
   return (
     <>
       <div
-        className={`fixed inset-0 z-30 bg-black/30 transition-opacity ${open ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+        className={`fixed inset-0 z-30 bg-black/30 transition-opacity ${
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
         onClick={onClose}
       />
       <aside
-        className={`fixed right-0 top-0 z-40 h-full w-64 bg-white p-4 border-l border-gray-200 transform transition-transform ${open ? "translate-x-0" : "translate-x-full"}`}
+        className={`fixed right-0 top-0 z-40 h-full w-64 bg-white p-4 border-l border-gray-200 transform transition-transform ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
         aria-hidden={!open}
       >
         <div className="flex justify-between mb-4">
@@ -21,7 +41,44 @@ export default function CartDrawer({ open, onClose }) {
             <XMarkIcon className="size-5" />
           </button>
         </div>
-        <p>Carrito vacío</p>
+        {items.length === 0 ? (
+          <p>Carrito vacío</p>
+        ) : (
+          <div className="flex flex-col h-full">
+            <ul className="flex-1 overflow-auto divide-y">
+              {items.map((item) => (
+                <li key={item.id} className="py-2 flex items-center justify-between gap-2">
+                  <span className="flex-1 text-sm">{item.title}</span>
+                  <input
+                    type="number"
+                    min={1}
+                    value={item.quantity}
+                    onChange={(e) => handleQtyChange(item.id, e.target.value)}
+                    className="w-12 border rounded px-1 py-0.5 text-sm"
+                  />
+                  <button
+                    className="text-red-600 text-xs"
+                    onClick={() => dispatch(removeItem(item.id))}
+                  >
+                    Eliminar
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-4 border-t pt-2 text-sm">
+              <p className="flex justify-between">
+                <span>Total:</span>
+                <span>${totalAmount.toFixed(2)}</span>
+              </p>
+              <button
+                className="mt-2 w-full rounded bg-gray-200 px-3 py-1 text-sm"
+                onClick={() => dispatch(clearCart())}
+              >
+                Vaciar carrito
+              </button>
+            </div>
+          </div>
+        )}
       </aside>
     </>
   );

--- a/src/Components/GlassProductCard.jsx
+++ b/src/Components/GlassProductCard.jsx
@@ -1,6 +1,8 @@
 // src/Components/GlassProductCard.jsx
 // Card clickeable en estilo claro, sin blur ni glass, textos más oscuros.
 import { Link } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { addItem } from "../store/cartSlice";
 import { productUrl } from "../routes/paths"; // ajustá el path si tu estructura difiere
 
 export default function GlassProductCard({ item }) {
@@ -16,6 +18,7 @@ export default function GlassProductCard({ item }) {
         media = {},
     } = item || {};
 
+    const dispatch = useDispatch();
     const money = (n, curr = currency) =>
         new Intl.NumberFormat("es-AR", {
             style: "currency",
@@ -34,6 +37,11 @@ export default function GlassProductCard({ item }) {
 
     // si hay id → detalle; si no, cae al cta.href por compatibilidad
     const to = id ? productUrl(id) : (cta?.href || "#");
+
+    const handleAdd = (e) => {
+        e.preventDefault();
+        dispatch(addItem({ id, title, price }));
+    };
 
     return (
         <Link
@@ -100,6 +108,12 @@ export default function GlassProductCard({ item }) {
             )}
 
             <div className="mt-auto" />
+            <button
+                onClick={handleAdd}
+                className="mt-4 rounded bg-black px-4 py-2 text-sm font-medium text-white hover:bg-black/80"
+            >
+                Add to cart
+            </button>
         </Link>
     );
 }

--- a/src/store/cartSlice.js
+++ b/src/store/cartSlice.js
@@ -1,32 +1,75 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-const initialState = {
-    items: [],
+const getInitialState = () => {
+  if (typeof localStorage === "undefined") {
+    return { items: [], totalQuantity: 0, totalAmount: 0 };
+  }
+  try {
+    const stored = localStorage.getItem("cart");
+    return stored
+      ? JSON.parse(stored)
+      : { items: [], totalQuantity: 0, totalAmount: 0 };
+  } catch {
+    return { items: [], totalQuantity: 0, totalAmount: 0 };
+  }
 };
 
+const saveState = (state) => {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem("cart", JSON.stringify(state));
+  } catch {
+    // ignore write errors
+  }
+};
+
+const calcTotals = (state) => {
+  state.totalQuantity = state.items.reduce((acc, i) => acc + i.quantity, 0);
+  state.totalAmount = state.items.reduce(
+    (acc, i) => acc + i.quantity * (i.price ?? 0),
+    0,
+  );
+};
+
+const initialState = getInitialState();
+
 const cartSlice = createSlice({
-    name: "cart",
-    initialState,
-    reducers: {
-        addItem: (state, action) => {
-            state.items.push(action.payload);
-        },
-        removeItem: (state, action) => {
-            state.items = state.items.filter((item) => item.id !== action.payload);
-        },
-        clearCart: (state) => {
-            state.items = [];
-        },
-        updateQuantity: (state, action) => {
-            const { id, quantity } = action.payload;
-            const item = state.items.find((item) => item.id === id);
-            if (item) {
-                item.quantity = quantity;
-            }
-        },
+  name: "cart",
+  initialState,
+  reducers: {
+    addItem: (state, action) => {
+      const item = action.payload;
+      const existing = state.items.find((i) => i.id === item.id);
+      if (existing) {
+        existing.quantity += item.quantity ?? 1;
+      } else {
+        state.items.push({ ...item, quantity: item.quantity ?? 1 });
+      }
+      calcTotals(state);
+      saveState(state);
     },
+    removeItem: (state, action) => {
+      state.items = state.items.filter((i) => i.id !== action.payload);
+      calcTotals(state);
+      saveState(state);
+    },
+    updateQuantity: (state, action) => {
+      const { id, quantity } = action.payload;
+      const item = state.items.find((i) => i.id === id);
+      if (item) {
+        item.quantity = quantity;
+      }
+      calcTotals(state);
+      saveState(state);
+    },
+    clearCart: (state) => {
+      state.items = [];
+      calcTotals(state);
+      saveState(state);
+    },
+  },
 });
 
-export const { addItem, removeItem, clearCart, updateQuantity } = cartSlice.actions;
+export const { addItem, removeItem, updateQuantity, clearCart } =
+  cartSlice.actions;
 export default cartSlice.reducer;
-

--- a/src/store/cartSlice.test.js
+++ b/src/store/cartSlice.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import cartReducer, {
+  addItem,
+  removeItem,
+  updateQuantity,
+  clearCart,
+} from "./cartSlice";
+import { configureStore } from "@reduxjs/toolkit";
+
+describe("cartSlice", () => {
+  beforeEach(() => {
+    global.localStorage = {
+      getItem: () => null,
+      setItem: () => null,
+    };
+  });
+
+  it("should return the initial state", () => {
+    const state = cartReducer(undefined, { type: "unknown" });
+    expect(state).toEqual({ items: [], totalQuantity: 0, totalAmount: 0 });
+  });
+
+  it("should add an item", () => {
+    const state = cartReducer(
+      undefined,
+      addItem({ id: 1, title: "Test", price: 10 })
+    );
+    expect(state.items).toHaveLength(1);
+    expect(state.totalQuantity).toBe(1);
+    expect(state.totalAmount).toBe(10);
+  });
+
+  it("should update quantity", () => {
+    const state = cartReducer(
+      { items: [{ id: 1, title: "Test", price: 10, quantity: 1 }], totalQuantity: 1, totalAmount: 10 },
+      updateQuantity({ id: 1, quantity: 3 })
+    );
+    expect(state.items[0].quantity).toBe(3);
+    expect(state.totalQuantity).toBe(3);
+    expect(state.totalAmount).toBe(30);
+  });
+
+  it("should remove item", () => {
+    const state = cartReducer(
+      { items: [{ id: 1, title: "Test", price: 10, quantity: 1 }], totalQuantity: 1, totalAmount: 10 },
+      removeItem(1)
+    );
+    expect(state.items).toHaveLength(0);
+    expect(state.totalQuantity).toBe(0);
+    expect(state.totalAmount).toBe(0);
+  });
+
+  it("should clear cart", () => {
+    const state = cartReducer(
+      { items: [{ id: 1, title: "Test", price: 10, quantity: 1 }], totalQuantity: 1, totalAmount: 10 },
+      clearCart()
+    );
+    expect(state.items).toHaveLength(0);
+    expect(state.totalQuantity).toBe(0);
+    expect(state.totalAmount).toBe(0);
+  });
+});
+
+describe("cartSlice integration", () => {
+  beforeEach(() => {
+    global.localStorage = {
+      getItem: () => null,
+      setItem: () => null,
+    };
+  });
+
+  it("allows adding, updating and removing items via store", () => {
+    const store = configureStore({ reducer: { cart: cartReducer } });
+    store.dispatch(addItem({ id: 1, title: "Test", price: 5 }));
+    store.dispatch(updateQuantity({ id: 1, quantity: 4 }));
+    expect(store.getState().cart.totalAmount).toBe(20);
+    store.dispatch(removeItem(1));
+    expect(store.getState().cart.items).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- expand cartSlice with totals and localStorage persistence
- wire product card and cart drawer to Redux actions
- document cart usage and add vitest setup with tests

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68abac471804832bb0939ea7235569b7