### PR TITLE
Add cart screen and route

### DIFF
--- a/src/Components/CartDrawer.jsx
+++ b/src/Components/CartDrawer.jsx
@@ -1,4 +1,5 @@
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { Link } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import {
   removeItem,
@@ -70,6 +71,13 @@ export default function CartDrawer({ open, onClose }) {
                 <span>Total:</span>
                 <span>${totalAmount.toFixed(2)}</span>
               </p>
+              <Link
+                to="/cart"
+                onClick={onClose}
+                className="mt-2 block w-full rounded bg-gray-900 px-3 py-1 text-center text-sm text-white"
+              >
+                Ver carrito
+              </Link>
               <button
                 className="mt-2 w-full rounded bg-gray-200 px-3 py-1 text-sm"
                 onClick={() => dispatch(clearCart())}

--- a/src/Screens/Cart.jsx
+++ b/src/Screens/Cart.jsx
@@ -1,0 +1,87 @@
+import { useSelector, useDispatch } from "react-redux";
+import { Link } from "react-router-dom";
+import { removeItem, updateQuantity, clearCart } from "../store/cartSlice";
+
+export default function Cart() {
+  const { items, totalAmount } = useSelector((s) => s.cart);
+  const dispatch = useDispatch();
+
+  const increment = (id, qty) =>
+    dispatch(updateQuantity({ id, quantity: qty + 1 }));
+  const decrement = (id, qty) => {
+    if (qty > 1) {
+      dispatch(updateQuantity({ id, quantity: qty - 1 }));
+    }
+  };
+
+  if (items.length === 0) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <h1 className="text-2xl font-bold mb-4">Carrito</h1>
+        <p className="text-gray-600">Tu carrito está vacío.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Carrito</h1>
+      <ul className="divide-y">
+        {items.map((item) => (
+          <li key={item.id} className="py-4 flex items-center gap-4">
+            <div className="flex-1">
+              <p className="font-medium">{item.title}</p>
+              {typeof item.price === "number" && (
+                <p className="text-sm text-gray-600">${item.price.toFixed(2)}</p>
+              )}
+            </div>
+            <div className="flex items-center">
+              <button
+                className="px-2 py-1 border rounded-l text-sm"
+                onClick={() => decrement(item.id, item.quantity)}
+                aria-label="Decrease quantity"
+              >
+                -
+              </button>
+              <span className="px-3 py-1 border-t border-b text-sm">
+                {item.quantity}
+              </span>
+              <button
+                className="px-2 py-1 border rounded-r text-sm"
+                onClick={() => increment(item.id, item.quantity)}
+                aria-label="Increase quantity"
+              >
+                +
+              </button>
+            </div>
+            <button
+              className="ml-4 text-red-600 text-sm"
+              onClick={() => dispatch(removeItem(item.id))}
+            >
+              Eliminar
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-6 border-t pt-4 space-y-2 text-sm">
+        <div className="flex justify-between font-medium">
+          <span>Total:</span>
+          <span>${totalAmount.toFixed(2)}</span>
+        </div>
+        <button
+          className="w-full rounded bg-gray-200 px-3 py-2"
+          onClick={() => dispatch(clearCart())}
+        >
+          Vaciar carrito
+        </button>
+        <Link
+          to="/checkout"
+          className="block w-full text-center rounded bg-gray-900 text-white px-3 py-2"
+        >
+          Ir a checkout
+        </Link>
+      </div>
+    </div>
+  );
+}
+

--- a/src/routes/Routes.jsx
+++ b/src/routes/Routes.jsx
@@ -6,6 +6,7 @@ import Layout from "./Layout";
 const Home = lazy(() => import("../Screens/Home.jsx"));
 const Shop = lazy(() => import("../Screens/Shop.jsx"));
 const ProductDetail = lazy(() => import("../Screens/ProductDetail.jsx")); // ← antes decía ../Screens/
+const Cart = lazy(() => import("../Screens/Cart.jsx"));
 
 const NotFound = () => (
     <div className="mx-auto max-w-3xl px-4 py-16">
@@ -22,6 +23,7 @@ export default function AppRoutes() {
                 { path: "/", element: <Home /> },
                 { path: "/shop", element: <Shop /> },
                 { path: "/producto/:id", element: <ProductDetail /> },
+                { path: "/cart", element: <Cart /> },
                 { path: "*", element: <NotFound /> },
             ],
         },


### PR DESCRIPTION
## Summary
- add Cart screen with quantity controls, remove, clear, checkout
- link cart drawer to full cart view
- register /cart route

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68abae525014832ba02651305ee131e4