### PR TITLE
Add cart quantity increment/decrement actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ El estado se persiste en `localStorage` para mantener los datos entre recargas.
 - `addItem({ id, title, price, quantity })`
 - `removeItem(id)`
 - `updateQuantity({ id, quantity })`
+- `incrementItem(id)`
+- `decrementItem(id)`
 - `clearCart()`
 
 ### Ejemplo de uso en componentes

--- a/src/Components/CartDrawer.jsx
+++ b/src/Components/CartDrawer.jsx
@@ -4,6 +4,8 @@ import {
   removeItem,
   updateQuantity,
   clearCart,
+  incrementItem,
+  decrementItem,
 } from "../store/cartSlice";
 
 export default function CartDrawer({ open, onClose }) {
@@ -49,13 +51,29 @@ export default function CartDrawer({ open, onClose }) {
               {items.map((item) => (
                 <li key={item.id} className="py-2 flex items-center justify-between gap-2">
                   <span className="flex-1 text-sm">{item.title}</span>
-                  <input
-                    type="number"
-                    min={1}
-                    value={item.quantity}
-                    onChange={(e) => handleQtyChange(item.id, e.target.value)}
-                    className="w-12 border rounded px-1 py-0.5 text-sm"
-                  />
+                  <div className="flex items-center gap-1">
+                    <button
+                      className="px-2 border rounded text-sm"
+                      aria-label="Decrease quantity"
+                      onClick={() => dispatch(decrementItem(item.id))}
+                    >
+                      -
+                    </button>
+                    <input
+                      type="number"
+                      min={1}
+                      value={item.quantity}
+                      onChange={(e) => handleQtyChange(item.id, e.target.value)}
+                      className="w-12 border rounded px-1 py-0.5 text-sm text-center"
+                    />
+                    <button
+                      className="px-2 border rounded text-sm"
+                      aria-label="Increase quantity"
+                      onClick={() => dispatch(incrementItem(item.id))}
+                    >
+                      +
+                    </button>
+                  </div>
                   <button
                     className="text-red-600 text-xs"
                     onClick={() => dispatch(removeItem(item.id))}

--- a/src/store/cartSlice.js
+++ b/src/store/cartSlice.js
@@ -53,6 +53,24 @@ const cartSlice = createSlice({
       calcTotals(state);
       saveState(state);
     },
+    incrementItem: (state, action) => {
+      const id = action.payload;
+      const item = state.items.find((i) => i.id === id);
+      if (item) {
+        item.quantity += 1;
+        calcTotals(state);
+        saveState(state);
+      }
+    },
+    decrementItem: (state, action) => {
+      const id = action.payload;
+      const item = state.items.find((i) => i.id === id);
+      if (item && item.quantity > 1) {
+        item.quantity -= 1;
+        calcTotals(state);
+        saveState(state);
+      }
+    },
     updateQuantity: (state, action) => {
       const { id, quantity } = action.payload;
       const item = state.items.find((i) => i.id === id);
@@ -70,6 +88,12 @@ const cartSlice = createSlice({
   },
 });
 
-export const { addItem, removeItem, updateQuantity, clearCart } =
-  cartSlice.actions;
+export const {
+  addItem,
+  removeItem,
+  updateQuantity,
+  clearCart,
+  incrementItem,
+  decrementItem,
+} = cartSlice.actions;
 export default cartSlice.reducer;

--- a/src/store/cartSlice.test.js
+++ b/src/store/cartSlice.test.js
@@ -4,6 +4,8 @@ import cartReducer, {
   removeItem,
   updateQuantity,
   clearCart,
+  incrementItem,
+  decrementItem,
 } from "./cartSlice";
 import { configureStore } from "@reduxjs/toolkit";
 
@@ -40,6 +42,26 @@ describe("cartSlice", () => {
     expect(state.totalAmount).toBe(30);
   });
 
+  it("should increment item quantity", () => {
+    const state = cartReducer(
+      { items: [{ id: 1, title: "Test", price: 10, quantity: 1 }], totalQuantity: 1, totalAmount: 10 },
+      incrementItem(1)
+    );
+    expect(state.items[0].quantity).toBe(2);
+    expect(state.totalQuantity).toBe(2);
+    expect(state.totalAmount).toBe(20);
+  });
+
+  it("should decrement item quantity", () => {
+    const state = cartReducer(
+      { items: [{ id: 1, title: "Test", price: 10, quantity: 2 }], totalQuantity: 2, totalAmount: 20 },
+      decrementItem(1)
+    );
+    expect(state.items[0].quantity).toBe(1);
+    expect(state.totalQuantity).toBe(1);
+    expect(state.totalAmount).toBe(10);
+  });
+
   it("should remove item", () => {
     const state = cartReducer(
       { items: [{ id: 1, title: "Test", price: 10, quantity: 1 }], totalQuantity: 1, totalAmount: 10 },
@@ -69,11 +91,13 @@ describe("cartSlice integration", () => {
     };
   });
 
-  it("allows adding, updating and removing items via store", () => {
+  it("allows adding, adjusting and removing items via store", () => {
     const store = configureStore({ reducer: { cart: cartReducer } });
     store.dispatch(addItem({ id: 1, title: "Test", price: 5 }));
-    store.dispatch(updateQuantity({ id: 1, quantity: 4 }));
-    expect(store.getState().cart.totalAmount).toBe(20);
+    store.dispatch(incrementItem(1));
+    expect(store.getState().cart.totalAmount).toBe(10);
+    store.dispatch(decrementItem(1));
+    expect(store.getState().cart.totalAmount).toBe(5);
     store.dispatch(removeItem(1));
     expect(store.getState().cart.items).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- add incrementItem and decrementItem reducers to cart slice with state persistence
- wire cart drawer +/- controls to new actions
- document and test new cart actions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68abae5478bc832bba8fa44c0e6aa2f6