### PR TITLE
Add breadcrumb navigation and sync subcategory filters

### DIFF
--- a/src/Components/Breadcrumbs.jsx
+++ b/src/Components/Breadcrumbs.jsx
@@ -1,0 +1,27 @@
+// src/Components/Breadcrumbs.jsx
+import { Link } from "react-router-dom";
+
+export default function Breadcrumbs({ segments = [] }) {
+    return (
+        <nav aria-label="Breadcrumb" className="mb-4">
+            <ol className="flex flex-wrap items-center gap-1 text-sm text-zinc-500">
+                {segments.map((seg, i) => {
+                    const isLast = i === segments.length - 1;
+                    const content = !isLast && seg.to ? (
+                        <Link to={seg.to} className="text-indigo-600 hover:underline">
+                            {seg.label}
+                        </Link>
+                    ) : (
+                        <span className={isLast ? "text-zinc-900" : undefined}>{seg.label}</span>
+                    );
+                    return (
+                        <li key={i} className="flex items-center gap-1">
+                            {content}
+                            {!isLast && <span className="text-zinc-400">/</span>}
+                        </li>
+                    );
+                })}
+            </ol>
+        </nav>
+    );
+}

--- a/src/Screens/ProductDetail.jsx
+++ b/src/Screens/ProductDetail.jsx
@@ -11,6 +11,7 @@ import {
 import { addItem } from "../store/cartSlice";
 import { PATHS } from "../routes/paths.js";
 import { tiles } from "../data/Products";
+import Breadcrumbs from "../Components/Breadcrumbs.jsx";
 
 export default function ProductDetail() {
     const { id } = useParams();
@@ -46,7 +47,29 @@ export default function ProductDetail() {
         media,
         stock: rawStock,
         freeShipping, // opcional en tus tiles
+        category,
+        subcategory,
     } = product;
+
+    const segments = useMemo(() => {
+        const segs = [];
+        if (category) {
+            segs.push({
+                label: category,
+                to: `${PATHS.shop}?category=${encodeURIComponent(category)}`,
+            });
+            if (subcategory) {
+                segs.push({
+                    label: subcategory,
+                    to: `${PATHS.shop}?category=${encodeURIComponent(
+                        category
+                    )}&subcategory=${encodeURIComponent(subcategory)}`,
+                });
+            }
+        }
+        segs.push({ label: title });
+        return segs;
+    }, [category, subcategory, title]);
 
     // Stock y validaciones
     const stock = Number.isFinite(rawStock) ? rawStock : Infinity;
@@ -319,6 +342,7 @@ export default function ProductDetail() {
 
                 {/* Columna derecha */}
                 <div className="lg:col-span-5 xl:col-span-4">
+                    <Breadcrumbs segments={segments} />
                     {/* Título y marca */}
                     <div className="space-y-1">
                         {brand && <p className="text-sm font-medium text-zinc-500">{brand}</p>}

--- a/src/Screens/Shop.jsx
+++ b/src/Screens/Shop.jsx
@@ -14,9 +14,10 @@ export default function Shop() {
   const query = searchParams.get("query")?.toLowerCase() || "";
   const initialMin = searchParams.get("min") ?? "";
   const initialMax = searchParams.get("max") ?? "";
+  const initialSub = searchParams.get("subcategory") ?? "";
 
   const [category, setCategory] = useState(initialCat);
-  const [subcategory, setSubcategory] = useState("");
+  const [subcategory, setSubcategory] = useState(initialSub);
   const [min, setMin] = useState(initialMin);
   const [max, setMax] = useState(initialMax);
   const [sort, setSort] = useState("relevance");
@@ -38,9 +39,11 @@ export default function Shop() {
       const params = new URLSearchParams(prev);
       if (category === "All") params.delete("category");
       else params.set("category", category);
+      if (subcategory) params.set("subcategory", subcategory);
+      else params.delete("subcategory");
       return params;
     });
-  }, [category, setSearchParams]);
+  }, [category, subcategory, setSearchParams]);
 
   useEffect(() => {
     const load = async () => {


### PR DESCRIPTION
## Summary
- add reusable Breadcrumbs component
- show breadcrumb trail on ProductDetail and link category filters
- sync subcategory with URL parameters in Shop screen

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c36e468832b803730eca4cb52c1