### PR TITLE
Add Mercado Pago sandbox checkout integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,12 @@ function Cart() {
 ```
 
 Consulta `src/Components/GlassProductCard.jsx` y `src/Components/CartDrawer.jsx` para ejemplos completos de integración.
+
+## Mercado Pago (modo de prueba)
+
+Para habilitar los pagos en el entorno de desarrollo se utilizan las siguientes variables de entorno:
+
+- `VITE_MP_PUBLIC_KEY`: *public key* de prueba utilizada en el frontend para inicializar el SDK de Mercado Pago.
+- `MP_ACCESS_TOKEN`: *access token* de prueba que debe configurar el backend para crear las preferencias de pago.
+
+Asegúrate de definirlas (por ejemplo en un archivo `.env`) antes de ejecutar la aplicación en modo de prueba.

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://sdk.mercadopago.com/js/v2"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/Screens/Checkout.jsx
+++ b/src/Screens/Checkout.jsx
@@ -4,6 +4,7 @@ import {
   decrementItem,
   updateQuantity,
 } from "../store/cartSlice";
+import { createPreference } from "../utils/mercadoPago.js";
 
 export default function Checkout() {
   // Toma items y, si existe en el slice, totalAmount
@@ -32,6 +33,12 @@ export default function Checkout() {
       currency: "USD", // si querés ARS cambiá a "ARS"
       maximumFractionDigits: 0,
     }).format(n ?? 0);
+
+  const handleConfirm = async () => {
+    new window.MercadoPago(import.meta.env.VITE_MP_PUBLIC_KEY);
+    const initPoint = await createPreference(items);
+    window.location.href = initPoint;
+  };
 
   if (!items.length) {
     return (
@@ -119,6 +126,7 @@ export default function Checkout() {
         <button
           type="button"
           className="rounded-lg bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 active:bg-indigo-800"
+          onClick={handleConfirm}
         >
           Confirmar compra
         </button>

--- a/src/utils/mercadoPago.js
+++ b/src/utils/mercadoPago.js
@@ -1,0 +1,14 @@
+export async function createPreference(items) {
+  const res = await fetch('/api/mp/create-preference', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ items })
+  });
+  if (!res.ok) {
+    throw new Error('Failed to create preference');
+  }
+  const data = await res.json();
+  return data.sandbox_init_point;
+}


### PR DESCRIPTION
## Summary
- load Mercado Pago SDK from index.html
- create helper to request payment preference
- hook checkout button to preference and redirect
- document Mercado Pago test environment variables

## Testing
- `npm test`
- `npm run lint` *(fails: React Hooks must be called in the same order; 'global' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6cf68460832bb8811a6700fd1acf