### PR TITLE
Add stepper-based checkout flow

### DIFF
--- a/src/Components/Checkout/AddressStep.jsx
+++ b/src/Components/Checkout/AddressStep.jsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+
+export default function AddressStep({ address, setAddress }) {
+  const [addresses, setAddresses] = useState([
+    "123 Main St, City",
+    "456 Market St, City",
+  ]);
+  const [newAddress, setNewAddress] = useState("");
+
+  const addAddress = () => {
+    const trimmed = newAddress.trim();
+    if (trimmed) {
+      setAddresses((a) => [...a, trimmed]);
+      setAddress(trimmed);
+      setNewAddress("");
+    }
+  };
+
+  return (
+    <div className="rounded-lg border bg-white p-6 shadow-sm space-y-4">
+      <h2 className="text-lg font-semibold">Select Address</h2>
+      <ul className="space-y-2">
+        {addresses.map((addr, idx) => (
+          <li key={idx} className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="address"
+              value={addr}
+              checked={address === addr}
+              onChange={() => setAddress(addr)}
+              className="h-4 w-4"
+            />
+            <span>{addr}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="pt-2 space-y-2">
+        <input
+          type="text"
+          value={newAddress}
+          onChange={(e) => setNewAddress(e.target.value)}
+          placeholder="Add new address"
+          className="w-full rounded border px-3 py-2 text-sm"
+        />
+        <button
+          type="button"
+          onClick={addAddress}
+          className="rounded border px-3 py-1 text-sm"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/Components/Checkout/PaymentStep.jsx
+++ b/src/Components/Checkout/PaymentStep.jsx
@@ -1,0 +1,128 @@
+import { useMemo } from "react";
+import { tiles } from "../../data/Products.js";
+
+export default function PaymentStep({
+  items,
+  address,
+  shipping,
+  money,
+  card,
+  setCard,
+}) {
+  const productIndex = useMemo(() => {
+    const map = new Map();
+    tiles.forEach((t) => map.set(t.id, t));
+    return map;
+  }, []);
+
+  const subtotal = items.reduce(
+    (acc, i) => acc + (i.price ?? 0) * (i.quantity ?? 1),
+    0
+  );
+  const tax = 50;
+  const shippingCost = 29;
+  const total = subtotal + tax + shippingCost;
+
+  const updateCard = (field, value) => {
+    setCard({ ...card, [field]: value });
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <div className="rounded-lg border bg-white p-6 shadow-sm space-y-4">
+        <h2 className="text-lg font-semibold">Payment Details</h2>
+        <input
+          type="text"
+          placeholder="Card number"
+          value={card.number}
+          onChange={(e) => updateCard("number", e.target.value)}
+          className="w-full rounded border px-3 py-2 text-sm"
+        />
+        <input
+          type="text"
+          placeholder="Name on card"
+          value={card.name}
+          onChange={(e) => updateCard("name", e.target.value)}
+          className="w-full rounded border px-3 py-2 text-sm"
+        />
+        <div className="flex gap-2">
+          <input
+            type="text"
+            placeholder="MM/YY"
+            value={card.expiry}
+            onChange={(e) => updateCard("expiry", e.target.value)}
+            className="w-full rounded border px-3 py-2 text-sm"
+          />
+          <input
+            type="text"
+            placeholder="CVV"
+            value={card.cvv}
+            onChange={(e) => updateCard("cvv", e.target.value)}
+            className="w-full rounded border px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+
+      <aside className="rounded-lg border bg-white p-6 shadow-sm space-y-4">
+        <h2 className="text-lg font-semibold">Summary</h2>
+        <ul className="space-y-4">
+          {items.map((item) => {
+            const p = productIndex.get(item.id);
+            const img = item.image ?? p?.media?.src;
+            const alt = p?.media?.alt ?? item.title;
+            const title = p?.title ?? item.title;
+            return (
+              <li key={`${item.id}-${item.variant ?? ""}`} className="flex items-center gap-4">
+                {img ? (
+                  <img
+                    src={img}
+                    alt={alt}
+                    className="h-16 w-16 rounded object-cover border"
+                  />
+                ) : (
+                  <div className="h-16 w-16 rounded bg-zinc-100" />
+                )}
+                <div className="flex-1">
+                  <p className="text-sm font-medium text-zinc-900">{title}</p>
+                  <p className="text-xs text-zinc-500">Qty {item.quantity ?? 1}</p>
+                </div>
+                <div className="text-sm font-medium">{money(item.price)}</div>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div className="text-sm space-y-1 pt-2">
+          <p>
+            <span className="font-medium">Address: </span>
+            {address}
+          </p>
+          <p>
+            <span className="font-medium">Shipping: </span>
+            {shipping}
+          </p>
+        </div>
+
+        <div className="space-y-2 text-sm pt-4 border-t">
+          <div className="flex justify-between">
+            <span>Subtotal</span>
+            <span>{money(subtotal)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Estimated Tax</span>
+            <span>{money(tax)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Shipping</span>
+            <span>{money(shippingCost)}</span>
+          </div>
+          <div className="flex justify-between font-semibold text-base">
+            <span>Total</span>
+            <span>{money(total)}</span>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}
+

--- a/src/Components/Checkout/ShippingStep.jsx
+++ b/src/Components/Checkout/ShippingStep.jsx
@@ -1,0 +1,29 @@
+const options = [
+  { value: "store", label: "Retiro en tienda" },
+  { value: "regular", label: "Envío regular" },
+  { value: "scheduled", label: "Envío programado" },
+];
+
+export default function ShippingStep({ shipping, setShipping }) {
+  return (
+    <div className="rounded-lg border bg-white p-6 shadow-sm space-y-4">
+      <h2 className="text-lg font-semibold">Shipping Method</h2>
+      <ul className="space-y-2">
+        {options.map((opt) => (
+          <li key={opt.value} className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="shipping"
+              value={opt.value}
+              checked={shipping === opt.value}
+              onChange={() => setShipping(opt.value)}
+              className="h-4 w-4"
+            />
+            <span>{opt.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/Components/Checkout/Stepper.jsx
+++ b/src/Components/Checkout/Stepper.jsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import AddressStep from "./AddressStep.jsx";
+import ShippingStep from "./ShippingStep.jsx";
+import PaymentStep from "./PaymentStep.jsx";
+
+const labels = ["Address", "Shipping", "Payment"];
+
+export default function Stepper({ items, money, handleConfirm }) {
+  const [step, setStep] = useState(1);
+  const [address, setAddress] = useState("");
+  const [shipping, setShipping] = useState("");
+  const [card, setCard] = useState({ number: "", name: "", expiry: "", cvv: "" });
+
+  const canNext =
+    (step === 1 && address) ||
+    (step === 2 && shipping) ||
+    (step === 3 && card.number && card.name && card.expiry && card.cvv);
+
+  const next = () => {
+    if (step === 3) {
+      handleConfirm();
+    } else {
+      setStep((s) => Math.min(3, s + 1));
+    }
+  };
+
+  const back = () => setStep((s) => Math.max(1, s - 1));
+
+  return (
+    <div className="space-y-6">
+      <div className="text-sm font-medium">{`Step ${step}: ${labels[step - 1]}`}</div>
+
+      {step === 1 && (
+        <AddressStep address={address} setAddress={setAddress} />
+      )}
+      {step === 2 && (
+        <ShippingStep shipping={shipping} setShipping={setShipping} />
+      )}
+      {step === 3 && (
+        <PaymentStep
+          items={items}
+          address={address}
+          shipping={shipping}
+          money={money}
+          card={card}
+          setCard={setCard}
+        />
+      )}
+
+      <div className="flex justify-between pt-4">
+        <button
+          type="button"
+          onClick={back}
+          disabled={step === 1}
+          className="rounded border px-4 py-2 text-sm disabled:opacity-50"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={next}
+          disabled={!canNext}
+          className="rounded bg-black px-4 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {step === 3 ? "Confirm" : "Next"}
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/Screens/Checkout.jsx
+++ b/src/Screens/Checkout.jsx
@@ -1,51 +1,16 @@
-// src/pages/Checkout.jsx
-import { useState, useMemo } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import {
-  incrementItem,
-  decrementItem,
-  updateQuantity,
-  removeItem,
-} from "../store/cartSlice";
+import { useSelector } from "react-redux";
+import Stepper from "../Components/Checkout/Stepper.jsx";
 import { createPreference } from "../utils/mercadoPago.js";
-import { XMarkIcon } from "@heroicons/react/24/outline";
-import { tiles } from "../data/Products.js";
 
 export default function Checkout() {
   const { items = [] } = useSelector((s) => s.cart) ?? {};
-  const dispatch = useDispatch();
-
-  // index rápido por id para traer media/título/brand
-  const productIndex = useMemo(() => {
-    const map = new Map();
-    tiles.forEach((t) => map.set(t.id, t));
-    return map;
-  }, []);
-
-  const [discountCode, setDiscountCode] = useState("");
-  const [bonusCard, setBonusCard] = useState("");
-
-  const subtotal = items.reduce(
-      (acc, i) => acc + (i.price ?? 0) * (i.quantity ?? 1),
-      0
-  );
-
-  // Para parecerse a la imagen: números fijos de “Estimated …”
-  const tax = 50;
-  const shipping = 29;
-  const total = subtotal + tax + shipping;
 
   const money = (n) =>
-      new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-        maximumFractionDigits: 0,
-      }).format(n ?? 0);
-
-  const handleQtyChange = (id, raw) => {
-    const n = Number(raw);
-    if (!Number.isNaN(n) && n > 0) dispatch(updateQuantity({ id, quantity: n }));
-  };
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(n ?? 0);
 
   const handleConfirm = async () => {
     new window.MercadoPago(import.meta.env.VITE_MP_PUBLIC_KEY);
@@ -55,158 +20,18 @@ export default function Checkout() {
 
   if (!items.length) {
     return (
-        <section className="mx-auto max-w-3xl px-4 py-12">
-          <h1 className="mb-4 text-3xl font-bold">Checkout</h1>
-          <p className="text-zinc-600">No hay productos en el carrito.</p>
-        </section>
+      <section className="mx-auto max-w-3xl px-4 py-12">
+        <h1 className="mb-4 text-3xl font-bold">Checkout</h1>
+        <p className="text-zinc-600">No hay productos en el carrito.</p>
+      </section>
     );
   }
 
   return (
-      <section className="mx-auto max-w-6xl px-4 py-12">
-        <h1 className="mb-8 text-3xl font-bold">Checkout</h1>
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
-          {/* IZQUIERDA: lista de productos */}
-          <div>
-            <h2 className="mb-6 text-lg font-semibold">Shopping Cart</h2>
-
-            <ul className="space-y-6">
-              {items.map((item) => {
-                const p = productIndex.get(item.id);
-                const img = item.image ?? p?.media?.src;
-                const alt = p?.media?.alt ?? item.title;
-                const title = p?.title ?? item.title;
-                const brand = p?.brand;
-
-                return (
-                    <li
-                        key={`${item.id}-${item.variant ?? ""}`}
-                        className="flex items-center gap-4"
-                    >
-                      {img ? (
-                          <img
-                              src={img}
-                              alt={alt}
-                              className="h-16 w-16 rounded object-cover border border-zinc-200"
-                          />
-                      ) : (
-                          <div className="h-16 w-16 rounded bg-zinc-100" />
-                      )}
-
-                      <div className="flex-1 min-w-0">
-                        <p className="truncate font-medium text-zinc-900">
-                          {brand ? `${brand} ` : ""}
-                          {title?.replace(/\n/g, " ")}
-                        </p>
-                        <p className="text-xs text-zinc-500">#{item.id}</p>
-
-                        <div className="mt-3 inline-flex items-center gap-2">
-                          <button
-                              type="button"
-                              className="h-8 w-8 rounded border text-zinc-700 disabled:opacity-40"
-                              onClick={() => dispatch(decrementItem(item.id))}
-                              disabled={(item.quantity ?? 1) <= 1}
-                              aria-label="Disminuir"
-                          >
-                            –
-                          </button>
-                          <input
-                              type="number"
-                              min={1}
-                              value={item.quantity ?? 1}
-                              onChange={(e) => handleQtyChange(item.id, e.target.value)}
-                              className="h-8 w-12 rounded border text-center"
-                              aria-label="Cantidad"
-                          />
-                          <button
-                              type="button"
-                              className="h-8 w-8 rounded border text-zinc-700"
-                              onClick={() => dispatch(incrementItem(item.id))}
-                              aria-label="Aumentar"
-                          >
-                            +
-                          </button>
-                        </div>
-                      </div>
-
-                      <div className="text-right">
-                        <p className="font-semibold">{money(item.price)}</p>
-                      </div>
-
-                      <button
-                          type="button"
-                          className="ml-2 text-zinc-400 hover:text-red-500"
-                          onClick={() => dispatch(removeItem(item.id))}
-                          aria-label="Quitar"
-                      >
-                        <XMarkIcon className="h-5 w-5" />
-                      </button>
-                    </li>
-                );
-              })}
-            </ul>
-          </div>
-
-          {/* DERECHA: resumen */}
-          <aside>
-            <h2 className="mb-6 text-lg font-semibold">Order Summary</h2>
-
-            <div className="rounded-lg border border-zinc-200 p-6 space-y-6 shadow-sm bg-white">
-              <div className="space-y-3">
-                <input
-                    type="text"
-                    value={discountCode}
-                    onChange={(e) => setDiscountCode(e.target.value)}
-                    placeholder="Discount code / Promo code"
-                    className="w-full rounded border border-zinc-300 px-3 py-2 text-sm"
-                />
-                <div className="flex gap-2">
-                  <input
-                      type="text"
-                      value={bonusCard}
-                      onChange={(e) => setBonusCard(e.target.value)}
-                      placeholder="Your bonus card number"
-                      className="flex-1 rounded border border-zinc-300 px-3 py-2 text-sm"
-                  />
-                  <button
-                      type="button"
-                      className="rounded border border-zinc-300 px-4 text-sm hover:bg-zinc-50"
-                  >
-                    Apply
-                  </button>
-                </div>
-              </div>
-
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-zinc-700">Subtotal</span>
-                  <span className="text-zinc-900">{money(subtotal)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-zinc-700">Estimated Tax</span>
-                  <span className="text-zinc-900">{money(tax)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-zinc-700">Estimated shipping &amp; Handling</span>
-                  <span className="text-zinc-900">{money(shipping)}</span>
-                </div>
-                <div className="flex justify-between font-semibold text-base border-t pt-4">
-                  <span>Total</span>
-                  <span>{money(total)}</span>
-                </div>
-              </div>
-
-              <button
-                  type="button"
-                  className="w-full rounded bg-black py-3 text-white font-medium hover:bg-zinc-800"
-                  onClick={handleConfirm}
-              >
-                Checkout
-              </button>
-            </div>
-          </aside>
-        </div>
-      </section>
+    <section className="mx-auto max-w-6xl px-4 py-12">
+      <h1 className="mb-8 text-3xl font-bold">Checkout</h1>
+      <Stepper items={items} money={money} handleConfirm={handleConfirm} />
+    </section>
   );
 }
+


### PR DESCRIPTION
## Summary
- implement checkout stepper with back/next flow
- add address, shipping and payment steps with summary panel
- integrate new stepper into Checkout screen

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: React Hook "useMemo" is called conditionally, 'global' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68aca165db20832bbddc9e196ffca7c9