### PR TITLE
Add related products section to product detail

### DIFF
--- a/src/Screens/ProductDetail.jsx
+++ b/src/Screens/ProductDetail.jsx
@@ -12,6 +12,7 @@ import { addItem } from "../store/cartSlice";
 import { PATHS } from "../routes/paths.js";
 import { tiles } from "../data/Products";
 import Breadcrumbs from "../Components/Breadcrumbs.jsx";
+import RelatedProductsSection from "../Sections/RelatedProductsSection.jsx";
 
 export default function ProductDetail() {
     const { id } = useParams();
@@ -531,6 +532,12 @@ export default function ProductDetail() {
                     {description || "Sin descripción disponible."}
                 </p>
             </div>
+
+            <RelatedProductsSection
+                excludeId={product.id}
+                category={category}
+                subcategory={subcategory}
+            />
         </section>
     );
 }

--- a/src/Sections/RelatedProductsSection.jsx
+++ b/src/Sections/RelatedProductsSection.jsx
@@ -1,0 +1,32 @@
+// src/Sections/RelatedProductsSection.jsx
+import { useMemo } from "react";
+import GlassProductCard from "../Components/GlassProductCard.jsx";
+import { tiles } from "../data/Products.js";
+
+export default function RelatedProductsSection({ category, subcategory, excludeId }) {
+    const related = useMemo(() => {
+        return tiles
+            .filter((t) => {
+                if (excludeId && String(t.id) === String(excludeId)) return false;
+                const sameCategory = category && t.category === category;
+                const sameSubcategory = subcategory && t.subcategory === subcategory;
+                return sameCategory || sameSubcategory;
+            })
+            .slice(0, 4);
+    }, [category, subcategory, excludeId]);
+
+    if (related.length === 0) return null;
+
+    return (
+        <section className="mt-12 border-t border-zinc-200 pt-6">
+            <h2 className="text-lg font-semibold text-zinc-900 mb-4">
+                Productos relacionados
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+                {related.map((item) => (
+                    <GlassProductCard key={item.id} item={item} />
+                ))}
+            </div>
+        </section>
+    );
+}


### PR DESCRIPTION
## Summary
- add RelatedProductsSection to suggest products from same category or subcategory
- render related products on ProductDetail page after description

## Testing
- `npm test`
- `npm run lint` *(fails: React Hooks called conditionally, no-undef, no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68acba4da698832ba78ee61138131910